### PR TITLE
chore: Update `css-inline` to `0.10`

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,7 +2,7 @@ black==23.1.0
 blinker==1.5
 click==8.1.3
 colorama==0.4.6
-css-inline==0.8.7
+css-inline==0.10.1
 dnspython==1.16.0
 eventlet==0.30.2
 face-recognition==1.3.0


### PR DESCRIPTION
Hi! This PR updates `css-inline` to its latest version